### PR TITLE
Fix for bug that makes padding not work at all

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.16_combat-6+build.2
 loader_version=0.12.12
 
 # Mod Properties
-mod_version=1.x.x
+mod_version=1.0.1
 maven_group=net.blumbo
 archives_base_name=ctsanticheat
 

--- a/src/main/java/net/blumbo/ctsanticheat/players/CombatUtil.java
+++ b/src/main/java/net/blumbo/ctsanticheat/players/CombatUtil.java
@@ -15,7 +15,7 @@ public class CombatUtil {
     // If target is not in reach (possibly due to ping) check if target's previous locations are in reach
     public static boolean allowReach(ServerPlayer attacker, ServerPlayer target) {
         Vec3 eyePosition = attacker.getEyePosition(0);
-        double reach = attacker.getCurrentAttackReach(1f);
+        double reach = attacker.getCurrentAttackReach(1F) + 1F;
         if (!attacker.canSee(target)) reach = 2.5;
         reach *= reach;
 


### PR DESCRIPTION
You removed padding entirely, which is fair, but on CTS especially, but all versions in general, padding is used to ensure good hitreg, and does not only affect players with high ping.